### PR TITLE
scripts/build_distro.sh : fix typo setting ROOTFS_DIR

### DIFF
--- a/scripts/build_distro.sh
+++ b/scripts/build_distro.sh
@@ -20,7 +20,7 @@ machine=$3
 
     cd ${topdir}/build/
 
-    ROOTFS_DIR=${topdir}/build/${distro}/tisdk-debian-${distro}}-rootfs
+    ROOTFS_DIR=${topdir}/build/${distro}/tisdk-debian-${distro}-rootfs
 }
 
 function package_and_clean() {


### PR DESCRIPTION
Just a simple leftover bracket